### PR TITLE
Fixes #999 Appearance of total points dialog

### DIFF
--- a/PowerUp/app/src/main/java/powerup/systers/com/ScenarioOverActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/ScenarioOverActivity.java
@@ -71,6 +71,8 @@ public class ScenarioOverActivity extends AppCompatActivity {
         Scenario prevScene = getmDbHandler().getScenarioFromID(SessionHistory.prevSessionID); //Fetching Scenario
         scenarioActivityDone = 1;
         if(!new ScenarioOverActivity(this).isActivityOpened()){
+            //If not launched from map then only dialogMaker() is called
+            if (!(getIntent().getExtras()!=null && PowerUpUtils.MAP.equals(getIntent().getExtras().getString(PowerUpUtils.SOURCE))))
             dialogMaker();
         }
         ImageView replayButton = (ImageView) findViewById(R.id.replayButton);


### PR DESCRIPTION
### Description
The PR contains changes such that the total points dialog on Scenario Over screen appears only if it is lauched after scenario completion and not from map.

Fixes #999 

### Type of Change:

- Code
- User Interface

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
The changes have been tested on android dtudio emulator
![back button](https://user-images.githubusercontent.com/26908195/37250768-840c30e8-2529-11e8-914a-d35e87a17c08.gif)

### Checklist:

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
- [ ] My PR currently breaks something (fix or feature that would cause existing functionality to not work as expected)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been published in downstream modules
